### PR TITLE
 fix: Refactor API endpoints for specialty

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/DoctorController.java
+++ b/backend/src/main/java/com/example/backend/controller/DoctorController.java
@@ -4,10 +4,9 @@ import java.util.List;
 
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -41,22 +40,12 @@ public class DoctorController {
         return ApiResponse.success(doctors, message);
     }
 
-    @GetMapping("/specialty/{specialtyId}")
-    @Operation(summary = "Get doctors by specialty", description = "Retrieve doctors filtered by specialty ID")
-    public ApiResponse<List<DoctorDto>> getDoctorsBySpecialty(@PathVariable Long specialtyId) {
-        List<DoctorDto> doctors = doctorService.getDoctorsBySpecialty(specialtyId);
-        String message = messageSource.getMessage("success.doctors.by.specialty.retrieved", null,
-                LocaleContextHolder.getLocale());
-        return ApiResponse.success(doctors, message);
-    }
-
-    @GetMapping("/search")
-    @Operation(summary = "Search doctors with pagination", description = "Search and filter doctors with pagination support")
-    public ApiResponse<PageResponse<DoctorDto>> searchDoctors(
-            @ModelAttribute DoctorSearchRequest request) {
-        PageResponse<DoctorDto> result = doctorService.searchDoctors(request);
-        String message = messageSource.getMessage("success.operation", null,
-                LocaleContextHolder.getLocale());
-        return ApiResponse.success(result, message);
-    }
+	@GetMapping("/search")
+	@Operation(summary = "Search doctors with pagination", description = "Search and filter doctors with pagination support")
+	public ApiResponse<PageResponse<DoctorDto>> searchDoctors(@ModelAttribute DoctorSearchRequest request) {
+		PageResponse<DoctorDto> result = doctorService.searchDoctors(request);
+		String message = messageSource.getMessage("success.operation", null,
+				LocaleContextHolder.getLocale());
+		return ApiResponse.success(result, message);
+	}
 }

--- a/backend/src/main/java/com/example/backend/controller/SpecialtyController.java
+++ b/backend/src/main/java/com/example/backend/controller/SpecialtyController.java
@@ -1,20 +1,25 @@
 package com.example.backend.controller;
 
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.example.backend.constant.ApiConstants;
 import com.example.backend.dto.ApiResponse;
 import com.example.backend.dto.PageResponse;
 import com.example.backend.dto.SpecialtyDto;
 import com.example.backend.dto.SpecialtySearchRequest;
+import com.example.backend.service.DoctorService;
 import com.example.backend.service.SpecialtyService;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.MessageSource;
-import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.web.bind.annotation.*;
-
-import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping(ApiConstants.SPECIALTIES_ENDPOINT)
@@ -24,6 +29,7 @@ import jakarta.validation.Valid;
 public class SpecialtyController {
 
     private final SpecialtyService specialtyService;
+    private final DoctorService doctorService;
     private final MessageSource messageSource;
 
     @GetMapping("/search")
@@ -39,5 +45,13 @@ public class SpecialtyController {
                 LocaleContextHolder.getLocale());
 
         return ApiResponse.success(result, message);
+    }
+    @GetMapping("/{specialtyId}/doctors")
+    @Operation(summary = "Get doctors by specialty", description = "Retrieve doctors filtered by specialty ID")
+    public ApiResponse<List<DoctorDto>> getDoctorsBySpecialty(@PathVariable Long specialtyId) {
+        List<DoctorDto> doctors = doctorService.getDoctorsBySpecialty(specialtyId);
+        String message = messageSource.getMessage("success.doctors.by.specialty.retrieved", null,
+                LocaleContextHolder.getLocale());
+        return ApiResponse.success(doctors, message);
     }
 }

--- a/backend/src/main/java/com/example/backend/dto/DoctorDto.java
+++ b/backend/src/main/java/com/example/backend/dto/DoctorDto.java
@@ -1,24 +1,24 @@
 package com.example.backend.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.math.BigDecimal;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class DoctorDto {
-    private Long id;
-    private String fullName;
-    private String email;
-    private String phone;
-    private String title;
-    private String specialtyName;
-    private Integer experienceYears;
-    private String bio;
-    private BigDecimal consultationFee;
-}
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record DoctorDto(
+    Long id,
+    String fullName,
+    @Email(message = "email must be valid")
+    String email,
+    @Pattern(regexp = "^[+\\d\\s().-]{8,20}$", message = "phone number is invalid")
+    String phone,
+    String title,
+    String specialtyName,
+    @PositiveOrZero(message = "experienceYears must be >= 0")
+    Integer experienceYears,
+    String bio,
+    @DecimalMin(value = "0.0", inclusive = true, message = "consultationFee must be >= 0")
+    BigDecimal consultationFee
+) {}

--- a/backend/src/main/java/com/example/backend/mapper/DoctorMapper.java
+++ b/backend/src/main/java/com/example/backend/mapper/DoctorMapper.java
@@ -37,8 +37,10 @@ public class DoctorMapper {
             return Collections.emptyList();
         }
 
-        return doctors.stream().map(this::toDto).filter(Optional::isPresent).map(Optional::get)
-                .collect(Collectors.toList());
-    }
-
+		return doctors.stream()
+				.map(this::toDto)
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.collect(Collectors.toList());
+	}
 }

--- a/backend/src/main/java/com/example/backend/repository/DoctorRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/DoctorRepository.java
@@ -32,5 +32,4 @@ public interface DoctorRepository
             WHERE d.specialty.id = :specialtyId
             """)
     List<Doctor> findBySpecialty(@Param("specialtyId") Long specialtyId);
-
 }

--- a/backend/src/main/java/com/example/backend/repository/spec/DoctorSpecifications.java
+++ b/backend/src/main/java/com/example/backend/repository/spec/DoctorSpecifications.java
@@ -50,9 +50,8 @@ public final class DoctorSpecifications {
         return (root, cq, cb) -> cb.greaterThanOrEqualTo(root.get("consultationFee"), min);
     }
 
-    public static Specification<Doctor> feeMax(BigDecimal max) {
-        if (max == null)
-            return null;
-        return (root, cq, cb) -> cb.lessThanOrEqualTo(root.get("consultationFee"), max);
-    }
+	public static Specification<Doctor> feeMax(BigDecimal max) {
+		if (max == null) return null;
+		return (root, cq, cb) -> cb.lessThanOrEqualTo(root.get("consultationFee"), max);
+	}
 }

--- a/backend/src/main/java/com/example/backend/service/impl/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/service/impl/AppointmentServiceImpl.java
@@ -1,5 +1,14 @@
 package com.example.backend.service.impl;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.example.backend.dto.AppointmentCreateRequest;
 import com.example.backend.dto.AppointmentCreateResponse;
 import com.example.backend.entity.Appointment;
@@ -20,10 +29,9 @@ import com.example.backend.mapper.AppointmentMapper;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -106,7 +114,7 @@ public class AppointmentServiceImpl implements AppointmentService {
         return AppointmentMapper.buildFromServices(savedAppt, patient, slot, services, total,
                 request.notes());
     }
-
+    
     @Override
     @Transactional
     public AppointmentCreateResponse confirm(Long appointmentId) {


### PR DESCRIPTION
## Related Tickets
- [#TicketID](https://edu-redmine.sun-asterisk.vn/issues/91722)

## WHAT
- Di chuyển endpoint getDoctorsBySpecialty từ DoctorController sang SpecialtyController
- Thay đổi đường dẫn API từ /api/v1/doctors/specialty/{specialtyId} thành /api/v1/specialties/{specialtyId}/doctors

## HOW
- Thêm endpoint mới GET /specialties/{specialtyId}/doctors trong SpecialtyController
- Xóa endpoint cũ GET /doctors/specialty/{specialtyId} khỏi DoctorController

## WHY
- Tuân thủ chuẩn RESTful
- Tách biệt trách nhiệm
- Tính nhất quán và dễ bảo trì
- Cấu trúc resource hierarchy tốt hơn

## Evidence (Screenshot or Video)
**API đã được đổi từ doctors/specialty/{specialtyId} sang specialties/{specialtyId}/doctors , lấy danh sách doctors thuộc specialty**
<img width="1316" height="789" alt="Screenshot 2025-08-20 020121" src="https://github.com/user-attachments/assets/806667e0-e995-468c-883f-2a9540270b63" />
