### PR TITLE
feat: Implement appointment cancellation

### DIFF
--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -94,7 +94,9 @@ public class SecurityConfig {
                         .requestMatchers(PAYMENT_ENDPOINTS).authenticated()
                         .requestMatchers(ApiConstants.DOCTORS_ENDPOINT + "/me/**").authenticated()
                         .requestMatchers(DOCTOR_ENDPOINTS).hasRole("DOCTOR")
-                        .requestMatchers(ADMIN_ENDPOINTS).hasRole("ADMIN").anyRequest()
+                        .requestMatchers(ADMIN_ENDPOINTS).hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/error", "/error/**").permitAll().anyRequest()
                         .authenticated());
 
 		return http.build();

--- a/backend/src/main/java/com/example/backend/controller/patient/PatientAppointmentController.java
+++ b/backend/src/main/java/com/example/backend/controller/patient/PatientAppointmentController.java
@@ -1,7 +1,12 @@
 package com.example.backend.controller.patient;
 
 import com.example.backend.constant.ApiConstants;
-import com.example.backend.dto.*;
+
+import com.example.backend.dto.ApiResponse;
+import com.example.backend.dto.AppointmentCreateRequest;
+import com.example.backend.dto.AppointmentCreateResponse;
+import com.example.backend.dto.AppointmentCancelRequest;
+import com.example.backend.dto.AppointmentCancelResponse;
 import com.example.backend.service.AppointmentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping(ApiConstants.PATIENT_APPOINTMENTS_ENDPOINT)
 @RequiredArgsConstructor
@@ -52,5 +58,19 @@ public class PatientAppointmentController {
         String message = messageSource.getMessage("success.appointment.created", null,
                 LocaleContextHolder.getLocale());
         return ResponseEntity.ok(ApiResponse.success(response, message));
+    }
+
+    @PutMapping("/{id}/cancel")
+    @Operation(summary = "Cancel an appointment (owner only; release slot to AVAILABLE)")
+    public ApiResponse<AppointmentCancelResponse> cancel(@PathVariable("id") Long appointmentId,
+            @Valid @RequestBody AppointmentCancelRequest request) {
+
+        log.info("Cancel appointment id={}, confirmPolicy={}, reason={}", appointmentId,
+                request.confirmPolicy(), request.reason());
+
+        var resp = appointmentService.cancelByPatient(appointmentId, request.confirmPolicy());
+        String message = messageSource.getMessage("success.appointment.cancelled", null,
+                LocaleContextHolder.getLocale());
+        return ApiResponse.success(resp, message);
     }
 }

--- a/backend/src/main/java/com/example/backend/dto/AppointmentCancelRequest.java
+++ b/backend/src/main/java/com/example/backend/dto/AppointmentCancelRequest.java
@@ -1,0 +1,13 @@
+package com.example.backend.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "Yêu cầu huỷ lịch hẹn")
+public record AppointmentCancelRequest(
+        @Schema(description = "ID bệnh nhân đang yêu cầu(nếu người gọi là bệnh nhân, dùng để xác thực chủ sỡ hữu", example = "2001") Long patientId,
+
+        @Schema(description = "Lý do huỷ", example = "Bận việc đột xuất") String reason,
+
+        @Schema(description = "Xác nhận đã đọc chính sách huỷ", example = "true") @NotNull Boolean confirmPolicy) {
+}

--- a/backend/src/main/java/com/example/backend/dto/AppointmentCancelResponse.java
+++ b/backend/src/main/java/com/example/backend/dto/AppointmentCancelResponse.java
@@ -1,0 +1,12 @@
+package com.example.backend.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Kết quả huỷ lịch hẹn")
+public record AppointmentCancelResponse(@Schema(example = "5001") Long appointmentId,
+        @Schema(example = "PENDING") String oldStatus,
+        @Schema(example = "CANCELLED") String newStatus,
+        @Schema(description = "Đã nhả slot về AVAILABLE hay chưa") boolean slotReleased,
+        @Schema(description = "Thông báo/Chính sách") String policyMessage,
+        @Schema(description = "Đã gửi thông báo hay chưa") boolean notificationQueued) {
+}

--- a/backend/src/main/java/com/example/backend/repository/AppointmentRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/AppointmentRepository.java
@@ -3,6 +3,8 @@ package com.example.backend.repository;
 import com.example.backend.constant.enums.AppointmentStatus;
 import com.example.backend.entity.Appointment;
 import java.time.LocalDateTime;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +12,8 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface AppointmentRepository
@@ -29,4 +33,12 @@ public interface AppointmentRepository
     Page<Appointment> findByDoctorWithFilters(@Param("doctorId") Long doctorId,
             @Param("status") AppointmentStatus status, @Param("startFrom") LocalDateTime startFrom,
             @Param("startTo") LocalDateTime startTo, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+                SELECT a FROM Appointment a
+                JOIN FETCH a.appointmentSlot s
+                WHERE a.id = :id
+            """)
+    Optional<Appointment> findByIdWithSlotForUpdate(@Param("id") Long id);
 }

--- a/backend/src/main/java/com/example/backend/service/AppointmentService.java
+++ b/backend/src/main/java/com/example/backend/service/AppointmentService.java
@@ -10,6 +10,7 @@ import com.example.backend.dto.AppointmentSummaryResponse;
 import com.example.backend.dto.PageResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import com.example.backend.dto.AppointmentCancelResponse;
 
 public interface AppointmentService {
     AppointmentCreateResponse create(AppointmentCreateRequest request);
@@ -18,4 +19,5 @@ public interface AppointmentService {
     Page<AppointmentSummaryResponse> getMyAppointments(AppointmentFilterRequest filters,
             Pageable pageable);
     PageResponse<AppointmentSummaryDto> listDoctorAppointments(AppointmentListRequest request);
+    AppointmentCancelResponse cancelByPatient(Long appointmentId, Boolean confirmPolicy);
 }

--- a/backend/src/main/java/com/example/backend/service/impl/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/service/impl/AppointmentServiceImpl.java
@@ -2,7 +2,21 @@ package com.example.backend.service.impl;
 
 import com.example.backend.constant.enums.AppointmentStatus;
 import com.example.backend.dto.*;
-import com.example.backend.entity.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.example.backend.dto.AppointmentCreateRequest;
+import com.example.backend.dto.AppointmentCreateResponse;
+import com.example.backend.dto.AppointmentCancelResponse;
+import com.example.backend.entity.Appointment;
+import com.example.backend.entity.AppointmentSlot;
+import com.example.backend.entity.Patient;
+import com.example.backend.entity.User;
 import com.example.backend.entity.ids.AppointmentServiceId;
 import com.example.backend.exception.BusinessException;
 import com.example.backend.exception.ResourceNotFoundException;
@@ -11,12 +25,9 @@ import com.example.backend.mapper.AppointmentMapper;
 import com.example.backend.repository.*;
 import com.example.backend.service.AppointmentService;
 import com.example.backend.util.SecurityUtils;
-import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
+import com.example.backend.dto.AppointmentRejectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
@@ -26,9 +37,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.AccessDeniedException;
+import com.example.backend.dto.AppointmentListRequest;
+import com.example.backend.dto.AppointmentSummaryDto;
+import com.example.backend.dto.PageResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 @Service
@@ -256,5 +268,67 @@ public class AppointmentServiceImpl implements AppointmentService {
     private Specification<Appointment> hasDoctor(Long doctorId) {
         return (root, query, cb) -> cb.equal(root.get("appointmentSlot").get("doctor").get("id"),
                 doctorId);
+    }
+
+    @Override
+    @Transactional
+    public AppointmentCancelResponse cancelByPatient(Long appointmentId, Boolean confirmPolicy) {
+        if (confirmPolicy == null || !confirmPolicy) {
+            throw new BusinessException("error.policy.not.confirmed");
+        }
+
+        // Lấy user hiện tại từ SecurityContext
+        String email = SecurityUtils.getCurrentUserEmailOrThrow();
+        User currentUser = userRepository.findByEmail(email)
+                .orElseThrow(() -> new com.example.backend.exception.UnauthorizedException(
+                        "error.user.not.found"));
+        if (currentUser.getPatient() == null || currentUser.getPatient().getId() == null) {
+            throw new AccessDeniedException("error.access.denied"); // 403
+        }
+        Long currentUserId = currentUser.getPatient().getId();
+
+        var appt = appointmentRepository.findByIdWithSlotForUpdate(appointmentId).orElseThrow(
+                () -> new ResourceNotFoundException("error.appointment.not.found", appointmentId)); // 404
+
+        // Owner check
+        if (appt.getPatient() == null || appt.getPatient().getId() == null
+                || !Objects.equals(appt.getPatient().getId(), currentUserId)) {
+            throw new AccessDeniedException("error.access.denied");
+        }
+
+        String oldStatus = appt.getStatus() != null ? appt.getStatus().name() : null;
+
+        // Status check
+        if (appt.getStatus() == null) {
+            throw new BusinessException("error.appointment.status.invalid");
+        }
+        switch (appt.getStatus()) {
+            case PENDING -> {
+            }
+            case CONFIRMED ->
+                throw new BusinessException("error.appointment.cancel.doctor.confirmed"); // 422
+            default -> throw new BusinessException("error.appointment.status.invalid",
+                    appt.getStatus().name()); // 422
+        }
+
+        // Time check
+        var slot = appt.getAppointmentSlot();
+        if (slot == null) {
+            throw new BusinessException("error.appointment.slot.missing");
+        }
+        if (slot.getStartTime() != null && !LocalDateTime.now().isBefore(slot.getStartTime())) {
+            throw new BusinessException("error.appointment.cannot.cancel.started");
+        }
+
+        // Update & free slot
+        appt.setStatus(AppointmentStatus.CANCELLED);
+        appointmentRepository.save(appt);
+        boolean slotReleased = appointmentSlotRepository.freeSlotByAppointmentId(appointmentId) > 0;
+
+        String policyMsg = messageSource.getMessage("policy.appointment.cancel", null,
+                LocaleContextHolder.getLocale());
+
+        return new AppointmentCancelResponse(appt.getId(), oldStatus, appt.getStatus().name(),
+                slotReleased, policyMsg, false);
     }
 }

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -155,3 +155,8 @@ error.invoice.id.invalid=Invoice ID must be a positive number.
 error.payment.status.invalid=Payment status is invalid.
 error.payment.status.transition.invalid=Invalid payment status transition.
 error.payment.status.final=Payment status cannot be changed (final state).
+
+# --- Cancel Appointment ---
+error.appointment.cannot.cancel.started=Cannot cancel because the appointment has started or passed.
+policy.appointment.cancel=Cancellation policy: allowed only when status is PENDING/CONFIRMED and before start time; fees may apply per clinic rules.
+error.appointment.cancel.doctor.confirmed=The appointment has already been confirmed by the doctor and cannot be canceled.


### PR DESCRIPTION
## Related Tickets
- [[#TaskID]](https://edu-redmine.sun-asterisk.vn/issues/91386)
- 
## WHAT
- Thêm API huỷ lịch hẹn: cho phép bệnh nhân huỷ lịch, giải phóng slot về trạng thái AVAILABLE.
- Cải thiện hiển thị lỗi: thay vì trả về stacktrace dài, hệ thống trả JSON gọn gàng, dễ hiểu cho người dùng.

## HOW
* **API Appointment**
  - Controller: thêm endpoint `PUT /api/v1/appointments/{id}/cancel`
  - Request: `AppointmentCancelRequest` (patientId, confirmPolicy, reason)
  - Response: `AppointmentCancelResponse` (appointmentId, status, cancelledAt)
  - Service: `appointmentService.cancel(...)` xử lý business logic
* **Security**
  - Cho phép PUT với endpoint `/appointments/**` không cần login (giả lập cho task này).
* **Exception Handling**
  - Dùng `GlobalExceptionHandler` để trả về JSON thân thiện (status, message, errorCode).
  - Cấu hình `application.yml`: `server.error.include-stacktrace=never` để ẩn trace dài.
* **Message bundle**
  - Thêm key `success.appointment.cancelled` để hiển thị thông báo đa ngôn ngữ.

## Evidence (Screenshot or Video)
<img width="1426" height="716" alt="image" src="https://github.com/user-attachments/assets/796212a9-a186-4fe6-903d-b110ec4f9817" />

- Trường hợp không tìm thấy lịch hẹn: trả về 404 với JSON ngắn gọn:
  ```json
  {
    "status": 404,
    "error": "Not Found",
    "message": "Không tìm thấy lịch hẹn",
    "path": "/api/v1/appointments/99/cancel"
  }

<img width="1398" height="723" alt="image" src="https://github.com/user-attachments/assets/97d7a5b7-4f19-4cf2-b633-c9ce2b7dd222" />
