### PR TITLE
feat: Implement API get my appointments with filters

### DIFF
--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -38,14 +38,15 @@ public class SecurityConfig {
             "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html", "/actuator/**",
             "/api/v1/auth/verify-email"};
 
-    private static final String[] PUBLIC_GET_ENDPOINTS = {
-            ApiConstants.SPECIALTIES_ENDPOINT + "/**"};
+    private static final String[] PUBLIC_GET_ENDPOINTS = {ApiConstants.SPECIALTIES_ENDPOINT + "/**",
+            ApiConstants.DOCTORS_ENDPOINT + "/**"};
 
     private static final String[] PATIENT_ENDPOINTS = {
-            ApiConstants.PATIENT_APPOINTMENTS_ENDPOINT + "/**", "/payments/**", "/notifications/**",
+            ApiConstants.APPOINTMENTS_ENDPOINT + "/**", "/payments/**", "/notifications/**",
             "/feedback/**"};
 
     private static final String[] DOCTOR_ENDPOINTS = {
+            ApiConstants.DOCTORS_ENDPOINT + "/me/**",
             ApiConstants.DOCTOR_APPOINTMENTS_ENDPOINT + "/**",
             ApiConstants.DOCTOR_TIME_OFF_ENDPOINT + "/**"};
 
@@ -87,9 +88,7 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(authz -> authz.requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                         .requestMatchers(HttpMethod.GET, PUBLIC_GET_ENDPOINTS).permitAll()
-                        .requestMatchers(PATIENT_ENDPOINTS).permitAll()
-                        // ensure me endpoints hit controller so @PreAuthorize can format response
-                        .requestMatchers(ApiConstants.DOCTORS_ENDPOINT + "/me/**").authenticated()
+                        .requestMatchers(PATIENT_ENDPOINTS).hasRole("PATIENT")
                         .requestMatchers(DOCTOR_ENDPOINTS).hasRole("DOCTOR")
                         .requestMatchers(ADMIN_ENDPOINTS).hasRole("ADMIN").anyRequest()
                         .authenticated());

--- a/backend/src/main/java/com/example/backend/controller/patient/PatientAppointmentController.java
+++ b/backend/src/main/java/com/example/backend/controller/patient/PatientAppointmentController.java
@@ -10,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,17 +22,35 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Patient Appointments", description = "Patient appointment management APIs")
 public class PatientAppointmentController {
 
+    private static final String ME_ENDPOINT = "/me";
+
     private final AppointmentService appointmentService;
     private final MessageSource messageSource;
 
+    @GetMapping(ME_ENDPOINT)
+    @Operation(summary = "Get my appointments with filters and pagination")
+    public ResponseEntity<ApiResponse<PageResponse<AppointmentSummaryResponse>>> getMyAppointments(
+            @Valid @ModelAttribute AppointmentFilterRequest filters, Pageable pageable) {
+
+        Page<AppointmentSummaryResponse> appointmentsPage = appointmentService
+                .getMyAppointments(filters, pageable);
+
+        PageResponse<AppointmentSummaryResponse> pageResponse = PageResponse.of(appointmentsPage);
+
+        String successMessage = messageSource.getMessage("success.appointments.retrieved", null,
+                LocaleContextHolder.getLocale());
+
+        return ResponseEntity.ok(ApiResponse.success(pageResponse, successMessage));
+    }
+
     @PostMapping
-    @Operation(summary = "Create appointment from an AVAILABLE slot")
-    public ApiResponse<AppointmentCreateResponse> create(
+    @Operation(summary = "Create an appointment from an AVAILABLE slot")
+    public ResponseEntity<ApiResponse<AppointmentCreateResponse>> create(
             @Valid @RequestBody AppointmentCreateRequest request) {
-        log.info("Create appointment: {}", request);
-        var resp = appointmentService.create(request);
+        log.info("Request to create appointment: {}", request);
+        AppointmentCreateResponse response = appointmentService.create(request);
         String message = messageSource.getMessage("success.appointment.created", null,
                 LocaleContextHolder.getLocale());
-        return ApiResponse.success(resp, message);
+        return ResponseEntity.ok(ApiResponse.success(response, message));
     }
 }

--- a/backend/src/main/java/com/example/backend/dto/AppointmentFilterRequest.java
+++ b/backend/src/main/java/com/example/backend/dto/AppointmentFilterRequest.java
@@ -1,0 +1,19 @@
+package com.example.backend.dto;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+import java.time.LocalDate;
+
+@Data
+public class AppointmentFilterRequest {
+
+    private String status;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate startDate;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate endDate;
+
+    private Long doctorId;
+}

--- a/backend/src/main/java/com/example/backend/dto/AppointmentSummaryResponse.java
+++ b/backend/src/main/java/com/example/backend/dto/AppointmentSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.example.backend.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class AppointmentSummaryResponse {
+    private Long id;
+    private String doctorName;
+    private String specialtyName;
+    private LocalDateTime appointmentTime;
+    private String status;
+}

--- a/backend/src/main/java/com/example/backend/dto/DoctorDto.java
+++ b/backend/src/main/java/com/example/backend/dto/DoctorDto.java
@@ -1,24 +1,22 @@
 package com.example.backend.dto;
 
-import java.math.BigDecimal;
-
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
+import java.math.BigDecimal;
+import lombok.Builder;
 
+@Builder
 public record DoctorDto(
-    Long id,
-    String fullName,
-    @Email(message = "email must be valid")
-    String email,
-    @Pattern(regexp = "^[+\\d\\s().-]{8,20}$", message = "phone number is invalid")
-    String phone,
-    String title,
-    String specialtyName,
-    @PositiveOrZero(message = "experienceYears must be >= 0")
-    Integer experienceYears,
-    String bio,
-    @DecimalMin(value = "0.0", inclusive = true, message = "consultationFee must be >= 0")
-    BigDecimal consultationFee
-) {}
+        Long id,
+        String fullName,
+        @Email(message = "email must be valid") String email,
+        @Pattern(regexp = "^[+\\d\\s().-]{8,20}$", message = "phone number is invalid")
+        String phone,
+        String title,
+        String specialtyName,
+        @PositiveOrZero(message = "experienceYears must be >= 0") Integer experienceYears,
+        String bio,
+        @DecimalMin(value = "0.0", inclusive = true, message = "consultationFee must be >= 0")
+        BigDecimal consultationFee) {}

--- a/backend/src/main/java/com/example/backend/mapper/AppointmentMapper.java
+++ b/backend/src/main/java/com/example/backend/mapper/AppointmentMapper.java
@@ -4,6 +4,7 @@ import com.example.backend.dto.AppointmentCreateResponse;
 import com.example.backend.dto.AppointmentCreateResponse.DoctorInfo;
 import com.example.backend.dto.AppointmentCreateResponse.ServiceItem;
 import com.example.backend.dto.AppointmentCreateResponse.SlotInfo;
+import com.example.backend.dto.AppointmentSummaryResponse;
 import com.example.backend.entity.Appointment;
 import com.example.backend.entity.AppointmentSlot;
 import com.example.backend.entity.Doctor;
@@ -13,14 +14,19 @@ import com.example.backend.entity.User;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-public final class AppointmentMapper {
-    private AppointmentMapper() {
-    }
+@Mapper(componentModel = "spring")
+public interface AppointmentMapper {
 
-    public static AppointmentCreateResponse buildFromServices(Appointment savedAppt,
-            Patient patient, AppointmentSlot slot,
-            List<com.example.backend.entity.Service> services, BigDecimal total, String notes) {
+    @Mapping(source = "appointmentSlot.doctor.user.fullName", target = "doctorName")
+    @Mapping(source = "appointmentSlot.doctor.specialty.name", target = "specialtyName")
+    AppointmentSummaryResponse toAppointmentSummaryResponse(Appointment appointment);
+
+    static AppointmentCreateResponse buildFromServices(Appointment savedAppt, Patient patient,
+                                                       AppointmentSlot slot, List<com.example.backend.entity.Service> services,
+                                                       BigDecimal total, String notes) {
         Doctor doctor = slot.getDoctor();
         Specialty specialty = doctor.getSpecialty();
         User user = doctor.getUser();
@@ -28,18 +34,18 @@ public final class AppointmentMapper {
                 new SlotInfo(slot.getStartTime(), slot.getEndTime(), doctor.getId()),
                 new DoctorInfo(doctor.getId(),
                         Optional.ofNullable(user).map(User::getFullName).orElse(null),
-                        Optional.ofNullable(specialty).map(s -> s.getId().longValue()).orElse(null),
+                        Optional.ofNullable(specialty).map(s -> s.getId().longValue())
+                                .orElse(null),
                         Optional.ofNullable(specialty).map(Specialty::getName).orElse(null)),
-                savedAppt.getStatus().name(),
-                services.stream()
-                        .map(svc -> new ServiceItem(svc.getId(), svc.getName(), svc.getPrice()))
-                        .toList(),
+                savedAppt.getStatus().name(), services.stream()
+                .map(svc -> new ServiceItem(svc.getId(), svc.getName(), svc.getPrice()))
+                .toList(),
                 total, notes);
     }
 
-    public static AppointmentCreateResponse buildFromAppointmentServices(Appointment appt,
-            AppointmentSlot slot,
-            List<com.example.backend.entity.AppointmentService> apptServices) {
+    static AppointmentCreateResponse buildFromAppointmentServices(Appointment appt,
+                                                                  AppointmentSlot slot,
+                                                                  List<com.example.backend.entity.AppointmentService> apptServices) {
         Doctor doctor = slot.getDoctor();
         Specialty specialty = doctor.getSpecialty();
         User user = doctor.getUser();
@@ -50,13 +56,13 @@ public final class AppointmentMapper {
                 new SlotInfo(slot.getStartTime(), slot.getEndTime(), doctor.getId()),
                 new DoctorInfo(doctor.getId(),
                         Optional.ofNullable(user).map(User::getFullName).orElse(null),
-                        Optional.ofNullable(specialty).map(s -> s.getId().longValue()).orElse(null),
+                        Optional.ofNullable(specialty).map(s -> s.getId().longValue())
+                                .orElse(null),
                         Optional.ofNullable(specialty).map(Specialty::getName).orElse(null)),
-                appt.getStatus().name(),
-                apptServices.stream()
-                        .map(as -> new ServiceItem(as.getService().getId(),
-                                as.getService().getName(), as.getPriceAtBooking()))
-                        .toList(),
+                appt.getStatus().name(), apptServices.stream()
+                .map(as -> new ServiceItem(as.getService().getId(),
+                        as.getService().getName(), as.getPriceAtBooking()))
+                .toList(),
                 total, appt.getNotes());
     }
 }

--- a/backend/src/main/java/com/example/backend/repository/AppointmentRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/AppointmentRepository.java
@@ -2,17 +2,18 @@ package com.example.backend.repository;
 
 import com.example.backend.constant.enums.AppointmentStatus;
 import com.example.backend.entity.Appointment;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
-
 @Repository
-public interface AppointmentRepository extends JpaRepository<Appointment, Long> {
+public interface AppointmentRepository extends JpaRepository<Appointment, Long>,
+        JpaSpecificationExecutor<Appointment> {
 
     @Query("""
             SELECT a FROM Appointment a
@@ -24,6 +25,6 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long> 
             ORDER BY s.startTime DESC
             """)
     Page<Appointment> findByDoctorWithFilters(@Param("doctorId") Long doctorId,
-            @Param("status") AppointmentStatus status, @Param("startFrom") LocalDateTime startFrom,
-            @Param("startTo") LocalDateTime startTo, Pageable pageable);
+                                              @Param("status") AppointmentStatus status, @Param("startFrom") LocalDateTime startFrom,
+                                              @Param("startTo") LocalDateTime startTo, Pageable pageable);
 }

--- a/backend/src/main/java/com/example/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/UserRepository.java
@@ -1,19 +1,20 @@
 package com.example.backend.repository;
 
 import com.example.backend.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByEmail(String email);
-
+    @EntityGraph(attributePaths = "roles")
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 
     Optional<User> findByVerificationToken(String token);
 

--- a/backend/src/main/java/com/example/backend/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/backend/security/JwtAuthenticationFilter.java
@@ -1,22 +1,20 @@
 package com.example.backend.security;
 
-import com.example.backend.entity.User;
-import com.example.backend.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -24,27 +22,22 @@ import java.util.stream.Collectors;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider tokenProvider;
-    private final UserRepository userRepository;
+    private final UserDetailsService userDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-            FilterChain filterChain) throws ServletException, IOException {
+                                    FilterChain filterChain) throws ServletException, IOException {
         try {
-            String jwt = getJwtFromRequest(request);
+            String jwt = getTokenFromRequest(request);
 
             if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-                String email = tokenProvider.getUsernameFromToken(jwt);
-                // Fetch user with roles to avoid LazyInitializationException
-                User user = userRepository.findByEmailWithRoles(email).orElse(null);
-                if (user != null && user.isActive()) {
-                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                            user, null,
-                            user.getRoles().stream()
-                                    .map(role -> new SimpleGrantedAuthority(
-                                            "ROLE_" + role.getRoleName().name()))
-                                    .collect(Collectors.toList()));
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                }
+                String email = tokenProvider.getEmailFromToken(jwt);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authentication
+                        .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (Exception ex) {
             log.error("Could not set user authentication in security context", ex);
@@ -53,7 +46,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String getJwtFromRequest(HttpServletRequest request) {
+    private String getTokenFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);

--- a/backend/src/main/java/com/example/backend/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/example/backend/security/JwtTokenProvider.java
@@ -26,27 +26,26 @@ public class JwtTokenProvider {
 
     @PostConstruct
     public void init() {
-        // convert chuỗi secret thành key hợp lệ
         signingKey = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String generateToken(String username) {
+    public String generateToken(String email) { // ĐÃ SỬA
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + jwtExpirationMs);
 
-        return Jwts.builder().setSubject(username).setIssuedAt(now).setExpiration(expiryDate)
+        return Jwts.builder().setSubject(email).setIssuedAt(now).setExpiration(expiryDate)
                 .signWith(signingKey, SignatureAlgorithm.HS256).compact();
     }
 
-    public String generateRefreshToken(String username) {
+    public String generateRefreshToken(String email) { // ĐÃ SỬA
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + refreshExpirationMs);
 
-        return Jwts.builder().setSubject(username).setIssuedAt(now).setExpiration(expiryDate)
+        return Jwts.builder().setSubject(email).setIssuedAt(now).setExpiration(expiryDate)
                 .signWith(signingKey, SignatureAlgorithm.HS256).compact();
     }
 
-    public String getUsernameFromToken(String token) {
+    public String getEmailFromToken(String token) { // ĐÃ SỬA
         return Jwts.parserBuilder().setSigningKey(signingKey).build().parseClaimsJws(token)
                 .getBody().getSubject();
     }

--- a/backend/src/main/java/com/example/backend/security/RestAccessDeniedHandler.java
+++ b/backend/src/main/java/com/example/backend/security/RestAccessDeniedHandler.java
@@ -3,16 +3,15 @@ package com.example.backend.security;
 import com.example.backend.constant.ErrorCodes;
 import com.example.backend.dto.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
@@ -23,7 +22,7 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
-            AccessDeniedException accessDeniedException) throws IOException {
+                       AccessDeniedException accessDeniedException) throws IOException {
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json;charset=UTF-8");
 
@@ -32,9 +31,6 @@ public class RestAccessDeniedHandler implements AccessDeniedHandler {
         ApiResponse<Void> body = ApiResponse.error(ErrorCodes.ACCESS_DENIED, message,
                 HttpServletResponse.SC_FORBIDDEN);
 
-        byte[] json = objectMapper.writeValueAsBytes(body);
-        response.setContentLength(json.length);
-        response.getOutputStream().write(json);
-        response.getOutputStream().flush();
+        objectMapper.writeValue(response.getOutputStream(), body);
     }
 }

--- a/backend/src/main/java/com/example/backend/security/RestAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/example/backend/security/RestAuthenticationEntryPoint.java
@@ -3,16 +3,15 @@ package com.example.backend.security;
 import com.example.backend.constant.ErrorCodes;
 import com.example.backend.dto.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
@@ -23,7 +22,7 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
-            AuthenticationException authException) throws IOException {
+                         AuthenticationException authException) throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
 
@@ -32,9 +31,6 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
         ApiResponse<Void> body = ApiResponse.error(ErrorCodes.UNAUTHORIZED, message,
                 HttpServletResponse.SC_UNAUTHORIZED);
 
-        byte[] json = objectMapper.writeValueAsBytes(body);
-        response.setContentLength(json.length);
-        response.getOutputStream().write(json);
-        response.getOutputStream().flush();
+        objectMapper.writeValue(response.getOutputStream(), body);
     }
 }

--- a/backend/src/main/java/com/example/backend/service/AppointmentService.java
+++ b/backend/src/main/java/com/example/backend/service/AppointmentService.java
@@ -2,14 +2,19 @@ package com.example.backend.service;
 
 import com.example.backend.dto.AppointmentCreateRequest;
 import com.example.backend.dto.AppointmentCreateResponse;
+import com.example.backend.dto.AppointmentFilterRequest;
 import com.example.backend.dto.AppointmentListRequest;
-import com.example.backend.dto.AppointmentSummaryDto;
-import com.example.backend.dto.PageResponse;
 import com.example.backend.dto.AppointmentRejectRequest;
+import com.example.backend.dto.AppointmentSummaryDto;
+import com.example.backend.dto.AppointmentSummaryResponse;
+import com.example.backend.dto.PageResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface AppointmentService {
     AppointmentCreateResponse create(AppointmentCreateRequest request);
-    AppointmentCreateResponse confirm(Long appointmentId); // trả về DTO tóm tắt
+    AppointmentCreateResponse confirm(Long appointmentId);
     AppointmentCreateResponse reject(Long appointmentId, AppointmentRejectRequest request);
-    PageResponse<AppointmentSummaryDto> listMyAppointments(AppointmentListRequest request);
+    Page<AppointmentSummaryResponse> getMyAppointments(AppointmentFilterRequest filters, Pageable pageable);
+    PageResponse<AppointmentSummaryDto> listDoctorAppointments(AppointmentListRequest request);
 }

--- a/backend/src/main/java/com/example/backend/service/impl/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/service/impl/AppointmentServiceImpl.java
@@ -1,50 +1,35 @@
 package com.example.backend.service.impl;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.example.backend.dto.AppointmentCreateRequest;
-import com.example.backend.dto.AppointmentCreateResponse;
-import com.example.backend.entity.Appointment;
-import com.example.backend.entity.AppointmentSlot;
-import com.example.backend.entity.Patient;
-import com.example.backend.entity.User;
+import com.example.backend.constant.enums.AppointmentStatus;
+import com.example.backend.dto.*;
+import com.example.backend.entity.*;
 import com.example.backend.entity.ids.AppointmentServiceId;
 import com.example.backend.exception.BusinessException;
 import com.example.backend.exception.ResourceNotFoundException;
-import com.example.backend.repository.AppointmentRepository;
-import com.example.backend.repository.AppointmentServiceRepository;
-import com.example.backend.repository.AppointmentSlotRepository;
-import com.example.backend.repository.PatientRepository;
-import com.example.backend.repository.ServiceRepository;
-import com.example.backend.repository.UserRepository;
+import com.example.backend.exception.UnauthorizedException;
+import com.example.backend.mapper.AppointmentMapper;
+import com.example.backend.repository.*;
 import com.example.backend.service.AppointmentService;
+import com.example.backend.util.SecurityUtils;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-
+import java.util.Locale;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.example.backend.dto.AppointmentListRequest;
-import com.example.backend.dto.AppointmentSummaryDto;
-import com.example.backend.dto.PageResponse;
-import com.example.backend.util.SecurityUtils;
-import com.example.backend.constant.enums.AppointmentStatus;
-import com.example.backend.dto.AppointmentRejectRequest;
-import com.example.backend.mapper.AppointmentMapper;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -57,6 +42,8 @@ public class AppointmentServiceImpl implements AppointmentService {
     private final ServiceRepository serviceRepository;
     private final PatientRepository patientRepository;
     private final UserRepository userRepository;
+    private final AppointmentMapper appointmentMapper;
+    private final MessageSource messageSource;
 
     @Override
     @Transactional
@@ -78,38 +65,33 @@ public class AppointmentServiceImpl implements AppointmentService {
                 .orElseThrow(() -> new ResourceNotFoundException("error.patient.not.found",
                         request.patientId()));
 
-        // Load services
         List<com.example.backend.entity.Service> services = serviceRepository
                 .findAllById(request.serviceIds());
         if (services.size() != request.serviceIds().size()) {
             throw new ResourceNotFoundException("error.service.not.found");
         }
 
-        // Validate specialty match
         Long slotSpecialtyId = slot.getDoctor().getSpecialty() != null
                 ? slot.getDoctor().getSpecialty().getId().longValue()
                 : null;
         boolean allMatch = services.stream()
-                .allMatch(svc -> svc.getSpecialty() != null && java.util.Objects
+                .allMatch(svc -> svc.getSpecialty() != null && Objects
                         .equals(svc.getSpecialty().getId().longValue(), slotSpecialtyId));
         if (!allMatch) {
             throw new BusinessException("error.service.specialty.mismatch");
         }
 
-        // Create Appointment (PENDING)
         Appointment appointmentToSave = new Appointment();
         appointmentToSave.setPatient(patient);
         appointmentToSave.setNotes(request.notes());
         appointmentToSave.setStatus(com.example.backend.constant.enums.AppointmentStatus.PENDING);
         final Appointment savedAppt = appointmentRepository.save(appointmentToSave);
 
-        // Reserve slot via CAS
         int updated = appointmentSlotRepository.reserveSlot(slot.getId(), savedAppt.getId());
         if (updated == 0) {
             throw new BusinessException("error.appointment.slot.unavailable");
         }
 
-        // Build AppointmentService rows and persist priceAtBooking
         List<com.example.backend.entity.AppointmentService> appointmentServices = services.stream()
                 .map(svc -> {
                     var as = new com.example.backend.entity.AppointmentService();
@@ -128,7 +110,7 @@ public class AppointmentServiceImpl implements AppointmentService {
         return AppointmentMapper.buildFromServices(savedAppt, patient, slot, services, total,
                 request.notes());
     }
-    
+
     @Override
     @Transactional
     public AppointmentCreateResponse confirm(Long appointmentId) {
@@ -172,7 +154,6 @@ public class AppointmentServiceImpl implements AppointmentService {
             throw new BusinessException("error.appointment.slot.missing");
         }
 
-        // policy: không cho hủy sau giờ bắt đầu
         if (slot.getStartTime().isBefore(LocalDateTime.now())) {
             throw new BusinessException("error.appointment.cannot.reject.after.start");
         }
@@ -180,7 +161,6 @@ public class AppointmentServiceImpl implements AppointmentService {
         appt.setStatus(AppointmentStatus.REJECTED);
         var saved = appointmentRepository.save(appt);
 
-        // free slot (CAS)
         appointmentSlotRepository.freeSlotByAppointmentId(saved.getId());
 
         var apptServices = appointmentServiceRepository.findByAppointmentId(saved.getId());
@@ -188,13 +168,41 @@ public class AppointmentServiceImpl implements AppointmentService {
     }
 
     @Override
+    public Page<AppointmentSummaryResponse> getMyAppointments(AppointmentFilterRequest filters,
+                                                              Pageable pageable) {
+        String currentUserEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+        User currentUser = userRepository.findByEmail(currentUserEmail).orElseThrow(() -> {
+            String message = messageSource.getMessage("error.unauthorized", null, new Locale("vi"));
+            return new RuntimeException(message);
+        });
+
+        Specification<Appointment> spec = isPatient(currentUser);
+
+        if (StringUtils.hasText(filters.getStatus())) {
+            spec = spec.and(hasStatus(filters.getStatus()));
+        }
+        if (filters.getStartDate() != null) {
+            spec = spec.and(isAfter(filters.getStartDate()));
+        }
+        if (filters.getEndDate() != null) {
+            spec = spec.and(isBefore(filters.getEndDate()));
+        }
+        if (filters.getDoctorId() != null) {
+            spec = spec.and(hasDoctor(filters.getDoctorId()));
+        }
+
+        Page<Appointment> appointments = appointmentRepository.findAll(spec, pageable);
+
+        return appointments.map(appointmentMapper::toAppointmentSummaryResponse);
+    }
+
+    @Override
     @Transactional(readOnly = true)
-    public PageResponse<AppointmentSummaryDto> listMyAppointments(AppointmentListRequest request) {
+    public PageResponse<AppointmentSummaryDto> listDoctorAppointments(AppointmentListRequest request) {
         String email = SecurityUtils.getCurrentUserEmailOrThrow();
 
         User currentUser = userRepository.findByEmail(email)
-                .orElseThrow(() -> new com.example.backend.exception.UnauthorizedException(
-                        "error.user.not.found"));
+                .orElseThrow(() -> new UnauthorizedException("error.user.not.found"));
         if (currentUser.getDoctor() == null) {
             throw new AccessDeniedException("error.access.denied");
         }
@@ -207,15 +215,38 @@ public class AppointmentServiceImpl implements AppointmentService {
         List<AppointmentSummaryDto> summaries = page.getContent().stream().map(a -> {
             AppointmentSlot s = a.getAppointmentSlot();
             Patient p = a.getPatient();
+            User patientUser = p != null ? p.getUser() : null;
             return new AppointmentSummaryDto(a.getId(), s != null ? s.getStartTime() : null,
                     s != null ? s.getEndTime() : null,
                     a.getStatus() != null ? a.getStatus().name() : null,
                     p != null ? p.getId() : null,
-                    p != null && p.getUser() != null ? p.getUser().getFullName() : null);
+                    patientUser != null ? patientUser.getFullName() : null);
         }).toList();
 
-        Page<AppointmentSummaryDto> dtoPage = new PageImpl<>(summaries, pageable,
-                page.getTotalElements());
+        Page<AppointmentSummaryDto> dtoPage = new PageImpl<>(summaries, pageable, page.getTotalElements());
         return PageResponse.of(dtoPage);
+    }
+
+    private Specification<Appointment> isPatient(User user) {
+        return (root, query, cb) -> cb.equal(root.get("patient").get("user"), user);
+    }
+
+    private Specification<Appointment> hasStatus(String status) {
+        return (root, query, cb) -> cb.equal(root.get("status"), AppointmentStatus.valueOf(status.trim().toUpperCase()));
+    }
+
+    private Specification<Appointment> isAfter(LocalDate startDate) {
+        return (root, query, cb) -> cb.greaterThanOrEqualTo(
+                root.get("appointmentSlot").get("startTime").as(LocalDate.class), startDate);
+    }
+
+    private Specification<Appointment> isBefore(LocalDate endDate) {
+        return (root, query, cb) -> cb.lessThanOrEqualTo(
+                root.get("appointmentSlot").get("startTime").as(LocalDate.class), endDate);
+    }
+
+    private Specification<Appointment> hasDoctor(Long doctorId) {
+        return (root, query, cb) -> cb.equal(root.get("appointmentSlot").get("doctor").get("id"),
+                doctorId);
     }
 }

--- a/backend/src/main/java/com/example/backend/service/impl/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/example/backend/service/impl/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.example.backend.service.impl;
+
+import com.example.backend.entity.User;
+import com.example.backend.repository.UserRepository;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email).orElseThrow(
+                () -> new UsernameNotFoundException("User not found with email: " + email));
+
+        return new org.springframework.security.core.userdetails.User(user.getEmail(),
+                user.getPasswordHash(),
+                user.getRoles().stream().map(
+                        role -> new SimpleGrantedAuthority("ROLE_" + role.getRoleName().name()))
+                        .collect(Collectors.toSet()));
+    }
+}

--- a/backend/src/main/resources/messages_vi.properties
+++ b/backend/src/main/resources/messages_vi.properties
@@ -60,6 +60,7 @@ success.specialty.search=Tìm kiếm chuyên khoa hoàn tất.
 success.doctor.time.off.created=Thêm lịch nghỉ thành công.
 success.doctors.retrieved=Lấy danh sách bác sĩ thành công.
 success.doctors.by.specialty.retrieved=Lấy danh sách bác sĩ theo chuyên khoa thành công.
+success.appointments.retrieved=Lấy danh sách lịch hẹn thành công.
 success.appointment.created=Thêm lịch hẹn thành công.
 success.appointment.confirmed=Xác nhận lịch hẹn thành công
 success.appointment.cancelled=Hủy lịch hẹn thành công


### PR DESCRIPTION
## Related Tickets
- [#TicketID](https://edu-redmine.sun-asterisk.vn/issues/91496)
- [#TicketID](https://edu-redmine.sun-asterisk.vn/issues/91539)
- [#TicketID](https://edu-redmine.sun-asterisk.vn/issues/91540)

## WHAT (optional)
- Xây dựng API endpoint mới cho phép người dùng (bệnh nhân) xem danh sách lịch hẹn của chính họ.
- API trả về danh sách lịch hẹn với các thông tin cơ bản

## HOW
- Tạo một `GET` endpoint mới tại `AppointmentController`.
- Sử dụng `Spring Data JPA Specification` để xây dựng các bộ lọc động, cho phép tìm kiếm theo:
+ Trạng thái lịch hẹn (`status`)
+ Khoảng thời gian (`startDate`, `endDate`)
+ Bác sĩ (`doctorId`)
- Tích hợp `Pageable` để hỗ trợ phân trang cho kết quả trả về.
- Thêm `AppointmentMapper` để chuyển đổi từ `Appointment Entity` sang `AppointmentSummaryResponse DTO`, đảm bảo chỉ trả về các thông tin cần thiết và tránh lộ dữ liệu không mong muốn.

## Evidence (Screenshot or Video)
- Kịch bản test: Gọi API với sự kết hợp của nhiều bộ lọc cùng lúc: `status`, `doctorId`, `startDate`, và `endDate`.
- Kết quả:
+ API trả về mã 200 OK, xác nhận logic hoạt động đúng.
+ Dữ liệu trả về có cấu trúc phân trang (pageable) và nội dung (content) chính xác như mong đợi.
<img width="1395" height="834" alt="image" src="https://github.com/user-attachments/assets/39f2bd2d-e403-40cc-b32c-b248cd50a334" />
