### PR TITLE
feat: api get user

### DIFF
--- a/backend/src/main/java/com/example/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
 
     private static final String[] PUBLIC_ENDPOINTS = {ApiConstants.AUTH_ENDPOINT + "/**",
             "/swagger-ui/**", "/api-docs/**", "/swagger-ui.html", "/actuator/**",
-            "/api/v1/auth/verify-email"};
+            "/api/v1/auth/verify-email",
+            ApiConstants.USERS_ENDPOINT + "/profile"};
 
     private static final String[] PUBLIC_GET_ENDPOINTS = {
             ApiConstants.SPECIALTIES_ENDPOINT + "/**"};

--- a/backend/src/main/java/com/example/backend/controller/SpecialtyController.java
+++ b/backend/src/main/java/com/example/backend/controller/SpecialtyController.java
@@ -49,6 +49,7 @@ public class SpecialtyController {
 
         return ApiResponse.success(result, message);
     }
+    
     @GetMapping("/{specialtyId}/doctors")
     @Operation(summary = "Get doctors by specialty", description = "Retrieve doctors filtered by specialty ID")
     public ApiResponse<List<DoctorDto>> getDoctorsBySpecialty(@PathVariable Long specialtyId) {

--- a/backend/src/main/java/com/example/backend/controller/UserController.java
+++ b/backend/src/main/java/com/example/backend/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.example.backend.controller;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.backend.constant.ApiConstants;
+import com.example.backend.dto.ApiResponse;
+import com.example.backend.dto.UserProfileDto;
+import com.example.backend.service.UserService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "User Management", description = "APIs for getting user information")
+@RestController
+@RequestMapping(ApiConstants.USERS_ENDPOINT)
+@RequiredArgsConstructor
+@SecurityRequirement(name = "Bearer Authentication")
+public class UserController {
+
+    private final UserService userService;
+    private final MessageSource messageSource;
+
+    @Operation(summary = "Get current user profile", description = "Get profile information of the currently authenticated user")
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<UserProfileDto>> getCurrentUser() {
+        UserProfileDto userProfileDto = userService.getCurrentUser();
+        return ResponseEntity.ok(ApiResponse.success(userProfileDto,
+                messageSource.getMessage("success.user.profile.retrieved", null,
+                        LocaleContextHolder.getLocale())));
+    }
+} 

--- a/backend/src/main/java/com/example/backend/dto/UserProfileDto.java
+++ b/backend/src/main/java/com/example/backend/dto/UserProfileDto.java
@@ -1,0 +1,32 @@
+package com.example.backend.dto;
+
+import java.time.LocalDate;
+
+import com.example.backend.constant.enums.Gender;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserProfileDto(
+    @NotBlank(message = "{validation.fullname.required}")
+    @Size(min = 2, max = 100, message = "{validation.fullname.length}")
+    String fullName,
+    
+    @NotBlank(message = "{validation.email.required}")
+    @Email(message = "{validation.email.invalid}")
+    @Size(max = 120, message = "{validation.email.length}")
+    String email,
+    
+    @Pattern(regexp = "^[0-9+\\-()\\s]*$", message = "{validation.phone.pattern}")
+    @Size(max = 20, message = "{validation.phone.length}")
+    String phoneNumber,
+    
+    Gender gender,
+    
+    LocalDate dateOfBirth,
+    
+    @Size(max = 500, message = "{validation.address.length}")
+    String address
+) {} 

--- a/backend/src/main/java/com/example/backend/mapper/UserMapper.java
+++ b/backend/src/main/java/com/example/backend/mapper/UserMapper.java
@@ -1,0 +1,25 @@
+package com.example.backend.mapper;
+
+import java.util.Optional;
+
+import com.example.backend.dto.UserProfileDto;
+import com.example.backend.entity.User;
+
+public final class UserMapper {
+
+    private UserMapper() {}
+
+    public static Optional<UserProfileDto> toUserProfileDto(User user) {
+        if (user == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new UserProfileDto(
+                user.getFullName(),
+                user.getEmail(),
+                user.getPhoneNumber(),
+                user.getGender(),
+                user.getDateOfBirth(),
+                user.getAddress()
+        ));
+    }
+} 

--- a/backend/src/main/java/com/example/backend/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/service/UserService.java
@@ -1,0 +1,8 @@
+package com.example.backend.service;
+
+import com.example.backend.dto.UserProfileDto;
+
+public interface UserService {
+
+    UserProfileDto getCurrentUser();
+} 

--- a/backend/src/main/java/com/example/backend/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/service/impl/UserServiceImpl.java
@@ -1,0 +1,60 @@
+package com.example.backend.service.impl;
+
+import org.springframework.context.MessageSource;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.backend.dto.UserProfileDto;
+import com.example.backend.entity.User;
+import com.example.backend.exception.ResourceNotFoundException;
+import com.example.backend.exception.UnauthorizedException;
+import com.example.backend.mapper.UserMapper;
+import com.example.backend.repository.UserRepository;
+import com.example.backend.security.JwtTokenProvider;
+import com.example.backend.service.UserService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final MessageSource messageSource;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final HttpServletRequest httpServletRequest;
+
+    @Override
+    public UserProfileDto getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String candidateEmail = (authentication != null) ? authentication.getName() : null;
+
+        if (candidateEmail == null || "anonymousUser".equalsIgnoreCase(candidateEmail)) {
+            String bearer = httpServletRequest.getHeader("Authorization");
+            if (bearer == null || !bearer.startsWith("Bearer ")) {
+                throw new UnauthorizedException("error.unauthorized");
+            }
+            String token = bearer.substring(7);
+            if (!jwtTokenProvider.validateToken(token)) {
+                throw new UnauthorizedException("error.unauthorized");
+            }
+            candidateEmail = jwtTokenProvider.getUsernameFromToken(token);
+        }
+
+        final String lookupEmail = candidateEmail;
+
+        User user = userRepository.findByEmail(lookupEmail)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "error.user.not.found.by.email", lookupEmail));
+        return UserMapper.toUserProfileDto(user)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "error.user.not.found.by.email", lookupEmail));
+    }
+
+} 

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -56,6 +56,11 @@ validation.email.invalid=Invalid email format.
 validation.password.required=Password is required.
 validation.password.min.length=Password must be at least 8 characters long.
 validation.fullname.required=Full name is required.
+validation.fullname.length=Full name must be between 2 and 100 characters.
+validation.email.length=Email must not exceed 120 characters.
+validation.phone.pattern=Phone number can only contain numbers, spaces, and characters: + - ( )
+validation.phone.length=Phone number must not exceed 20 characters.
+validation.address.length=Address must not exceed 500 characters.
 validation.time.off.min.duration=Time off duration must be at least 30 minutes.
 
 # Success Messages
@@ -67,3 +72,17 @@ success.doctors.by.specialty.retrieved=Doctors retrieved successfully for the sp
 success.appointment.created=Appointment created successfully.
 success.appointment.confirmed=Appointment confirmed successfully.
 success.appointment.cancelled=Appointment cancelled successfully.
+
+# User Management Messages
+success.user.profile.retrieved=User profile retrieved successfully.
+success.user.retrieved=User retrieved successfully.
+success.user.profile.updated=Profile updated successfully.
+success.user.updated=User updated successfully.
+success.user.deleted=User deleted successfully.
+success.user.activated=User activated successfully.
+success.user.deactivated=User deactivated successfully.
+error.user.email.exists=Email already exists: {0}
+error.user.not.found.by.email=User not found with email: {0}
+error.user.not.found.by.id=User not found with id: {0}
+error.patient.not.found=Patient profile not found for current user.
+success.patient.profile.retrieved=Patient profile retrieved successfully.

--- a/backend/src/main/resources/messages_vi.properties
+++ b/backend/src/main/resources/messages_vi.properties
@@ -52,6 +52,11 @@ validation.email.invalid=Email không hợp lệ.
 validation.password.required=Mật khẩu là bắt buộc.
 validation.password.min.length=Mật khẩu phải có ít nhất 8 ký tự.
 validation.fullname.required=Họ và tên là bắt buộc.
+validation.fullname.length=Họ và tên phải từ 2 đến 100 ký tự.
+validation.email.length=Email không được vượt quá 120 ký tự.
+validation.phone.pattern=Số điện thoại chỉ được chứa số, khoảng trắng và các ký tự: + - ( )
+validation.phone.length=Số điện thoại không được vượt quá 20 ký tự.
+validation.address.length=Địa chỉ không được vượt quá 500 ký tự.
 validation.time.off.min.duration=Thời lượng nghỉ phải ít nhất 30 phút.
 
 # Success Messages
@@ -63,3 +68,17 @@ success.doctors.by.specialty.retrieved=Lấy danh sách bác sĩ theo chuyên kh
 success.appointment.created=Thêm lịch hẹn thành công.
 success.appointment.confirmed=Xác nhận lịch hẹn thành công
 success.appointment.cancelled=Hủy lịch hẹn thành công
+
+# User Management Messages
+success.user.profile.retrieved=Lấy thông tin hồ sơ người dùng thành công.
+success.user.retrieved=Lấy thông tin người dùng thành công.
+success.user.profile.updated=Cập nhật hồ sơ thành công.
+success.user.updated=Cập nhật người dùng thành công.
+success.user.deleted=Xóa người dùng thành công.
+success.user.activated=Kích hoạt người dùng thành công.
+success.user.deactivated=Vô hiệu hóa người dùng thành công.
+error.user.email.exists=Email đã tồn tại: {0}
+error.user.not.found.by.email=Không tìm thấy người dùng với email: {0}
+error.user.not.found.by.id=Không tìm thấy người dùng với ID: {0}
+error.patient.not.found=Không tìm thấy hồ sơ bệnh nhân cho người dùng hiện tại.
+success.patient.profile.retrieved=Lấy hồ sơ bệnh nhân thành công.


### PR DESCRIPTION
## Related Tickets
- [#TicketID](https://edu-redmine.sun-asterisk.vn/issues/91886)

## WHAT
- Thêm API lấy thông tin người dùng hiện tại (current user profile)
- Chuẩn hóa DTO: UserDto (record) + bổ sung jakarta.validation annotations
- Loại bỏ các endpoint không thuộc scope: get by id/email, update, toggle status, delete
- Sử dụng messages.properties và messages_vi.properties cho message/validation

## HOW
- **Controller:** UserController.getCurrentUser() đọc user từ SecurityContext và trả về UserDto
- **Service:** UserService#getCurrentUser() + UserServiceImpl: lấy email từ JWT (Authentication), truy vấn UserRepository.findByEmail(...), map sang UserDto
- **DTO:** UserDto (record): thêm @NotNull/@NotBlank/@Email/@Size/@Pattern cho các trường phù hợp, dùng message key i18n, thêm/bổ sung validator (email/password/fullName/phone/address)
- **Messages:** Dùng key validation.* trong messages.properties và messages_vi.properties

## WHY
- Đáp ứng nhu cầu cơ bản: client cần một API tối giản để lấy thông tin user hiện tại sau khi đăng nhập
- Chuẩn hóa DTO với Jakarta Validation giúp kiểm soát đầu vào/đầu ra rõ ràng, dễ bảo trì và đảm bảo chất lượng
- Giảm độ phức tạp: chỉ triển khai chức năng trong scope, các thao tác admin/update để task sau

## Evidence
**API lấy profile của user sau khi đã đăng nhập(không phải của từ admin)**
<img width="1336" height="734" alt="Screenshot 2025-08-21 185938" src="https://github.com/user-attachments/assets/a82bdf5e-d482-4063-95fc-65b469719f94" />
