### PR TITLE
feat: implement doctor update appointment status

### DIFF
--- a/backend/src/main/java/com/example/backend/constant/enums/AppointmentStatus.java
+++ b/backend/src/main/java/com/example/backend/constant/enums/AppointmentStatus.java
@@ -1,5 +1,5 @@
 package com.example.backend.constant.enums;
 
 public enum AppointmentStatus {
-    PENDING, CONFIRMED, CANCELLED, COMPLETED, REJECTED
+    PENDING, CONFIRMED, CANCELLED, COMPLETED, REJECTED, NO_SHOW;
 }

--- a/backend/src/main/java/com/example/backend/controller/doctor/DoctorAppointmentController.java
+++ b/backend/src/main/java/com/example/backend/controller/doctor/DoctorAppointmentController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -53,5 +54,19 @@ public class DoctorAppointmentController {
         String message = messageSource.getMessage("success.appointment.rejected", null,
                 LocaleContextHolder.getLocale());
         return ApiResponse.success(resp, message);
+    }
+
+    @PatchMapping("/{appointmentId}/status")
+    @Operation(summary = "Update appointment status by Doctor")
+    public ResponseEntity<ApiResponse<AppointmentDetailResponse>> updateAppointmentStatus(
+            @PathVariable Long appointmentId,
+            @Valid @RequestBody UpdateAppointmentStatusRequest request) {
+
+        AppointmentDetailResponse responseDto = appointmentService
+                .updateStatusByDoctor(appointmentId, request);
+        ApiResponse<AppointmentDetailResponse> apiResponse = ApiResponse.success(responseDto,
+                "Cập nhật trạng thái thành công.");
+
+        return ResponseEntity.ok(apiResponse);
     }
 }

--- a/backend/src/main/java/com/example/backend/dto/AppointmentDetailResponse.java
+++ b/backend/src/main/java/com/example/backend/dto/AppointmentDetailResponse.java
@@ -1,0 +1,24 @@
+package com.example.backend.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AppointmentDetailResponse(Long id, String status, LocalDateTime appointmentTime,
+        LocalDateTime endTime, String notes, BigDecimal totalPrice, DoctorInfo doctor,
+        PatientInfo patient, List<ServiceItem> services, List<String> availableActions,
+        List<Object> history) {
+    @Builder
+    public record DoctorInfo(Long id, String fullName, String specialtyName) {
+    }
+
+    @Builder
+    public record PatientInfo(Long id, String fullName, String phoneNumber) {
+    }
+
+    @Builder
+    public record ServiceItem(Long id, String name, BigDecimal price) {
+    }
+}

--- a/backend/src/main/java/com/example/backend/dto/UpdateAppointmentStatusRequest.java
+++ b/backend/src/main/java/com/example/backend/dto/UpdateAppointmentStatusRequest.java
@@ -1,0 +1,8 @@
+package com.example.backend.dto;
+
+import com.example.backend.constant.enums.AppointmentStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateAppointmentStatusRequest(
+        @NotNull(message = "New status cannot be null") AppointmentStatus newStatus) {
+}

--- a/backend/src/main/java/com/example/backend/service/AppointmentService.java
+++ b/backend/src/main/java/com/example/backend/service/AppointmentService.java
@@ -1,16 +1,8 @@
 package com.example.backend.service;
 
-import com.example.backend.dto.AppointmentCreateRequest;
-import com.example.backend.dto.AppointmentCreateResponse;
-import com.example.backend.dto.AppointmentFilterRequest;
-import com.example.backend.dto.AppointmentListRequest;
-import com.example.backend.dto.AppointmentRejectRequest;
-import com.example.backend.dto.AppointmentSummaryDto;
-import com.example.backend.dto.AppointmentSummaryResponse;
-import com.example.backend.dto.PageResponse;
+import com.example.backend.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import com.example.backend.dto.AppointmentCancelResponse;
 
 public interface AppointmentService {
     AppointmentCreateResponse create(AppointmentCreateRequest request);
@@ -20,4 +12,7 @@ public interface AppointmentService {
             Pageable pageable);
     PageResponse<AppointmentSummaryDto> listDoctorAppointments(AppointmentListRequest request);
     AppointmentCancelResponse cancelByPatient(Long appointmentId, Boolean confirmPolicy);
+    AppointmentDetailResponse updateStatusByDoctor(Long appointmentId,
+            UpdateAppointmentStatusRequest request);
+    AppointmentDetailResponse getAppointmentDetails(Long id);
 }

--- a/backend/src/main/java/com/example/backend/service/impl/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/service/impl/AppointmentServiceImpl.java
@@ -2,24 +2,7 @@ package com.example.backend.service.impl;
 
 import com.example.backend.constant.enums.AppointmentStatus;
 import com.example.backend.dto.*;
-
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Objects;
-
-import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.example.backend.dto.AppointmentCreateRequest;
-import com.example.backend.dto.AppointmentCreateResponse;
-import com.example.backend.dto.AppointmentCancelResponse;
-import com.example.backend.entity.Appointment;
-import com.example.backend.entity.AppointmentSlot;
-import com.example.backend.entity.Patient;
-import com.example.backend.entity.User;
-import com.example.backend.entity.Doctor;
+import com.example.backend.entity.*;
 import com.example.backend.entity.ids.AppointmentServiceId;
 import com.example.backend.event.AppointmentConfirmedEvent;
 import com.example.backend.event.AppointmentCreatedEvent;
@@ -29,42 +12,35 @@ import com.example.backend.exception.BusinessException;
 import com.example.backend.exception.ResourceNotFoundException;
 import com.example.backend.exception.UnauthorizedException;
 import com.example.backend.mapper.AppointmentMapper;
-import com.example.backend.repository.AppointmentRepository;
-import com.example.backend.repository.AppointmentSlotRepository;
-import com.example.backend.repository.AppointmentServiceRepository;
-import com.example.backend.repository.ServiceRepository;
-import com.example.backend.repository.UserRepository;
+import com.example.backend.repository.*;
 import com.example.backend.service.AppointmentService;
 import com.example.backend.service.CalendarSyncService;
+import com.example.backend.service.InvoiceService;
 import com.example.backend.util.SecurityUtils;
-
-import java.time.LocalDate;
-import java.util.Locale;
-
-import com.example.backend.dto.AppointmentRejectRequest;
-
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.AccessDeniedException;
-
-import com.example.backend.dto.AppointmentListRequest;
-import com.example.backend.dto.AppointmentSummaryDto;
-import com.example.backend.dto.PageResponse;
-
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import com.example.backend.service.InvoiceService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -87,7 +63,6 @@ public class AppointmentServiceImpl implements AppointmentService {
     public AppointmentCreateResponse create(AppointmentCreateRequest request) {
         log.info("Creating appointment with slot {}", request.slotId());
 
-        // Lấy thông tin patient từ current user
         String email = SecurityUtils.getCurrentUserEmailOrThrow();
         User currentUser = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UnauthorizedException("error.user.not.found"));
@@ -148,7 +123,6 @@ public class AppointmentServiceImpl implements AppointmentService {
                 .map(com.example.backend.entity.AppointmentService::getPriceAtBooking)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
 
-        // Publish events for notifications
         publishAppointmentCreatedEvents(savedAppt, patient, slot, services, total, request.notes());
 
         return AppointmentMapper.buildFromServices(savedAppt, patient, slot, services, total,
@@ -160,7 +134,6 @@ public class AppointmentServiceImpl implements AppointmentService {
     public AppointmentCreateResponse confirm(Long appointmentId) {
         log.info("Confirm appointment: {}", appointmentId);
 
-        // Lấy thông tin doctor từ current user
         String email = SecurityUtils.getCurrentUserEmailOrThrow();
         User currentUser = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UnauthorizedException("error.user.not.found"));
@@ -182,7 +155,6 @@ public class AppointmentServiceImpl implements AppointmentService {
             throw new BusinessException("error.appointment.slot.missing");
         }
 
-        // Kiểm tra appointment có thuộc về current doctor không
         if (!Objects.equals(slot.getDoctor().getId(), currentDoctor.getId())) {
             throw new AccessDeniedException("error.access.denied");
         }
@@ -200,7 +172,7 @@ public class AppointmentServiceImpl implements AppointmentService {
             BigDecimal totalAmount = apptServices.stream()
                     .map(com.example.backend.entity.AppointmentService::getPriceAtBooking)
                     .reduce(BigDecimal.ZERO, BigDecimal::add);
-            
+
             invoiceService.createInvoiceForAppointment(saved.getId(), totalAmount);
             log.info("Auto-created invoice for confirmed appointment: {}", saved.getId());
         } catch (Exception e) {
@@ -211,9 +183,7 @@ public class AppointmentServiceImpl implements AppointmentService {
         // Sync to calendar when appointment is confirmed
         calendarSyncService.syncAppointmentToCalendar(saved);
 
-        // TODO: publish AppointmentConfirmedEvent here (Patient Notifications task)
-        
-        // Notification out of current scope: do not publish confirmed event
+        publishAppointmentConfirmedEvent(saved, slot);
 
         var apptServices = appointmentServiceRepository.findByAppointmentId(saved.getId());
         return AppointmentMapper.buildFromAppointmentServices(saved, slot, apptServices);
@@ -224,7 +194,6 @@ public class AppointmentServiceImpl implements AppointmentService {
     public AppointmentCreateResponse reject(Long appointmentId, AppointmentRejectRequest request) {
         log.info("Reject appointment: {}, reason: {}", appointmentId, request.reason());
 
-        // Lấy thông tin doctor từ current user
         String email = SecurityUtils.getCurrentUserEmailOrThrow();
         User currentUser = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UnauthorizedException("error.user.not.found"));
@@ -247,7 +216,6 @@ public class AppointmentServiceImpl implements AppointmentService {
             throw new BusinessException("error.appointment.slot.missing");
         }
 
-        // Kiểm tra appointment có thuộc về current doctor không
         if (!Objects.equals(slot.getDoctor().getId(), currentDoctor.getId())) {
             throw new AccessDeniedException("error.access.denied");
         }
@@ -267,9 +235,7 @@ public class AppointmentServiceImpl implements AppointmentService {
         // Sync to calendar when appointment is rejected
         calendarSyncService.syncAppointmentToCalendar(saved);
 
-        // TODO: publish AppointmentRejectedEvent here (Patient Notifications task)
-
-        // Notification out of current scope: do not publish rejected event
+        publishAppointmentRejectedEvent(saved, slot, request.reason());
 
         var apptServices = appointmentServiceRepository.findByAppointmentId(saved.getId());
         return AppointmentMapper.buildFromAppointmentServices(saved, slot, apptServices);
@@ -277,10 +243,10 @@ public class AppointmentServiceImpl implements AppointmentService {
 
     @Override
     public Page<AppointmentSummaryResponse> getMyAppointments(AppointmentFilterRequest filters,
-            Pageable pageable) {
+                                                              Pageable pageable) {
         String currentUserEmail = SecurityContextHolder.getContext().getAuthentication().getName();
         User currentUser = userRepository.findByEmail(currentUserEmail).orElseThrow(() -> {
-            String message = messageSource.getMessage("error.unauthorized", null, new Locale("vi"));
+            String message = messageSource.getMessage("error.unauthorized", null, LocaleContextHolder.getLocale());
             return new RuntimeException(message);
         });
 
@@ -337,6 +303,154 @@ public class AppointmentServiceImpl implements AppointmentService {
         return PageResponse.of(dtoPage);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public AppointmentDetailResponse getAppointmentDetails(Long id) {
+        log.info("Fetching details for appointment id: {}", id);
+
+        Appointment appointment = appointmentRepository.findById(id).orElseThrow(
+                () -> new ResourceNotFoundException("error.appointment.not.found", id));
+
+        return buildAppointmentDetailResponse(appointment);
+    }
+
+    @Override
+    @Transactional
+    public AppointmentCancelResponse cancelByPatient(Long appointmentId, Boolean confirmPolicy) {
+        if (confirmPolicy == null || !confirmPolicy) {
+            throw new BusinessException("error.policy.not.confirmed");
+        }
+
+        String email = SecurityUtils.getCurrentUserEmailOrThrow();
+        User currentUser = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UnauthorizedException("error.user.not.found"));
+        if (currentUser.getPatient() == null || currentUser.getPatient().getId() == null) {
+            throw new AccessDeniedException("error.access.denied");
+        }
+        Long currentUserId = currentUser.getPatient().getId();
+
+        var appt = appointmentRepository.findByIdWithSlotForUpdate(appointmentId).orElseThrow(
+                () -> new ResourceNotFoundException("error.appointment.not.found", appointmentId));
+
+        if (appt.getPatient() == null || appt.getPatient().getId() == null
+                || !Objects.equals(appt.getPatient().getId(), currentUserId)) {
+            throw new AccessDeniedException("error.access.denied");
+        }
+
+        String oldStatus = appt.getStatus() != null ? appt.getStatus().name() : null;
+
+        if (appt.getStatus() == null) {
+            throw new BusinessException("error.appointment.status.invalid");
+        }
+        switch (appt.getStatus()) {
+            case PENDING :
+                break;
+            case CONFIRMED :
+                throw new BusinessException("error.appointment.cancel.doctor.confirmed");
+            default :
+                throw new BusinessException("error.appointment.status.invalid",
+                        appt.getStatus().name());
+        }
+
+        var slot = appt.getAppointmentSlot();
+        if (slot == null) {
+            throw new BusinessException("error.appointment.slot.missing");
+        }
+        if (slot.getStartTime() != null && !LocalDateTime.now().isBefore(slot.getStartTime())) {
+            throw new BusinessException("error.appointment.cannot.cancel.started");
+        }
+
+        appt.setStatus(AppointmentStatus.CANCELLED);
+        appointmentRepository.save(appt);
+        boolean slotReleased = appointmentSlotRepository.freeSlotByAppointmentId(appointmentId) > 0;
+
+        String policyMsg = messageSource.getMessage("policy.appointment.cancel", null,
+                LocaleContextHolder.getLocale());
+
+        return new AppointmentCancelResponse(appt.getId(), oldStatus, appt.getStatus().name(),
+                slotReleased, policyMsg, false);
+    }
+
+    @Override
+    @Transactional
+    public AppointmentDetailResponse updateStatusByDoctor(Long appointmentId,
+                                                          UpdateAppointmentStatusRequest request) {
+        log.info("Doctor updating status for appointment {}: to {}", appointmentId,
+                request.newStatus());
+
+        Appointment appointment = appointmentRepository.findById(appointmentId).orElseThrow(
+                () -> new ResourceNotFoundException("error.appointment.not.found", appointmentId));
+
+        String currentUserEmail = SecurityUtils.getCurrentUserEmailOrThrow();
+        Long doctorUserIdOfAppointment = appointment.getAppointmentSlot().getDoctor().getUser()
+                .getId();
+        User currentUser = userRepository.findByEmail(currentUserEmail)
+                .orElseThrow(() -> new UnauthorizedException("error.user.not.found"));
+
+        if (!currentUser.getId().equals(doctorUserIdOfAppointment)) {
+            throw new AccessDeniedException("error.access.denied");
+        }
+
+        validateStatusTransition(appointment.getStatus(), request.newStatus());
+
+        appointment.setStatus(request.newStatus());
+        appointmentRepository.save(appointment);
+
+        log.info("Successfully updated status for appointment {}", appointmentId);
+
+        return buildAppointmentDetailResponse(appointment);
+    }
+
+    private void validateStatusTransition(AppointmentStatus current, AppointmentStatus next) {
+        if (current != AppointmentStatus.CONFIRMED) {
+            throw new BusinessException("error.appointment.invalid.state.for.update");
+        }
+
+        Set<AppointmentStatus> allowedNextStates = Set.of(AppointmentStatus.COMPLETED,
+                AppointmentStatus.CANCELLED);
+
+        if (!allowedNextStates.contains(next)) {
+            throw new BusinessException("error.appointment.invalid.next.state");
+        }
+    }
+
+    private AppointmentDetailResponse buildAppointmentDetailResponse(Appointment appointment) {
+        AppointmentSlot slot = appointment.getAppointmentSlot();
+        Doctor doctor = slot.getDoctor();
+        User doctorUser = doctor.getUser();
+        Specialty specialty = doctor.getSpecialty();
+        Patient patient = appointment.getPatient();
+        User patientUser = patient.getUser();
+        List<com.example.backend.entity.AppointmentService> apptServices = appointmentServiceRepository
+                .findByAppointmentId(appointment.getId());
+
+        BigDecimal totalPrice = apptServices.stream()
+                .map(com.example.backend.entity.AppointmentService::getPriceAtBooking)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        List<String> availableActions = new ArrayList<>();
+        if (appointment.getStatus() == AppointmentStatus.PENDING
+                || appointment.getStatus() == AppointmentStatus.CONFIRMED) {
+            availableActions.add("CANCEL");
+        }
+
+        return AppointmentDetailResponse.builder().id(appointment.getId())
+                .status(appointment.getStatus().name()).appointmentTime(slot.getStartTime())
+                .endTime(slot.getEndTime()).notes(appointment.getNotes()).totalPrice(totalPrice)
+                .doctor(AppointmentDetailResponse.DoctorInfo.builder().id(doctor.getId())
+                        .fullName(doctorUser.getFullName()).specialtyName(specialty.getName())
+                        .build())
+                .patient(AppointmentDetailResponse.PatientInfo.builder().id(patient.getId())
+                        .fullName(patientUser.getFullName())
+                        .phoneNumber(patientUser.getPhoneNumber()).build())
+                .services(apptServices.stream()
+                        .map(as -> AppointmentDetailResponse.ServiceItem.builder()
+                                .id(as.getService().getId()).name(as.getService().getName())
+                                .price(as.getPriceAtBooking()).build())
+                        .toList())
+                .availableActions(availableActions).history(List.of()).build();
+    }
+
     private Specification<Appointment> isPatient(User user) {
         return (root, query, cb) -> cb.equal(root.get("patient").get("user"), user);
     }
@@ -361,85 +475,20 @@ public class AppointmentServiceImpl implements AppointmentService {
                 doctorId);
     }
 
-    @Override
-    @Transactional
-    public AppointmentCancelResponse cancelByPatient(Long appointmentId, Boolean confirmPolicy) {
-        if (confirmPolicy == null || !confirmPolicy) {
-            throw new BusinessException("error.policy.not.confirmed");
-        }
-
-        // Lấy user hiện tại từ SecurityContext
-        String email = SecurityUtils.getCurrentUserEmailOrThrow();
-        User currentUser = userRepository.findByEmail(email)
-                .orElseThrow(() -> new com.example.backend.exception.UnauthorizedException(
-                        "error.user.not.found"));
-        if (currentUser.getPatient() == null || currentUser.getPatient().getId() == null) {
-            throw new AccessDeniedException("error.access.denied"); // 403
-        }
-        Long currentUserId = currentUser.getPatient().getId();
-
-        var appt = appointmentRepository.findByIdWithSlotForUpdate(appointmentId).orElseThrow(
-                () -> new ResourceNotFoundException("error.appointment.not.found", appointmentId)); // 404
-
-        // Owner check
-        if (appt.getPatient() == null || appt.getPatient().getId() == null
-                || !Objects.equals(appt.getPatient().getId(), currentUserId)) {
-            throw new AccessDeniedException("error.access.denied");
-        }
-
-        String oldStatus = appt.getStatus() != null ? appt.getStatus().name() : null;
-
-        // Status check
-        if (appt.getStatus() == null) {
-            throw new BusinessException("error.appointment.status.invalid");
-        }
-        switch (appt.getStatus()) {
-            case PENDING -> {
-            }
-            case CONFIRMED ->
-                throw new BusinessException("error.appointment.cancel.doctor.confirmed"); // 422
-            default -> throw new BusinessException("error.appointment.status.invalid",
-                    appt.getStatus().name()); // 422
-        }
-
-        // Time check
-        var slot = appt.getAppointmentSlot();
-        if (slot == null) {
-            throw new BusinessException("error.appointment.slot.missing");
-        }
-        if (slot.getStartTime() != null && !LocalDateTime.now().isBefore(slot.getStartTime())) {
-            throw new BusinessException("error.appointment.cannot.cancel.started");
-        }
-
-        // Update & free slot
-        appt.setStatus(AppointmentStatus.CANCELLED);
-        appointmentRepository.save(appt);
-        boolean slotReleased = appointmentSlotRepository.freeSlotByAppointmentId(appointmentId) > 0;
-
-        String policyMsg = messageSource.getMessage("policy.appointment.cancel", null,
-                LocaleContextHolder.getLocale());
-
-        return new AppointmentCancelResponse(appt.getId(), oldStatus, appt.getStatus().name(),
-                slotReleased, policyMsg, false);
-    }
-
-    // Event publishing methods
     private void publishAppointmentCreatedEvents(Appointment appointment, Patient patient,
-            AppointmentSlot slot, List<com.example.backend.entity.Service> services,
-            BigDecimal totalPrice, String notes) {
+                                                 AppointmentSlot slot, List<com.example.backend.entity.Service> services,
+                                                 BigDecimal totalPrice, String notes) {
 
         User patientUser = patient.getUser();
         Doctor doctor = slot.getDoctor();
         User doctorUser = doctor.getUser();
 
-        // Publish event for patient
         AppointmentCreatedEvent patientEvent = new AppointmentCreatedEvent(appointment.getId(),
                 patient.getId(), patientUser.getEmail(), patientUser.getFullName(),
                 slot.getStartTime(), slot.getEndTime(), doctor.getId(), doctorUser.getFullName(),
                 doctor.getSpecialty() != null ? doctor.getSpecialty().getName() : null, totalPrice);
         eventPublisher.publishEvent(patientEvent);
 
-        // Publish event for doctor
         List<String> serviceNames = services.stream()
                 .map(com.example.backend.entity.Service::getName).collect(Collectors.toList());
 
@@ -469,7 +518,7 @@ public class AppointmentServiceImpl implements AppointmentService {
     }
 
     private void publishAppointmentRejectedEvent(Appointment appointment, AppointmentSlot slot,
-            String reason) {
+                                                 String reason) {
         User patientUser = appointment.getPatient().getUser();
         Doctor doctor = slot.getDoctor();
         User doctorUser = doctor.getUser();


### PR DESCRIPTION
## Related Tickets
- [#TicketID](https://edu-redmine.sun-asterisk.vn/issues/92176)

## WHAT (optional)
- Bác sĩ có thể cập nhật trạng thái lịch hẹn (ví dụ: `COMPLETED`, `CANCELLED`, `NO_SHOW`).

## HOW
- Tạo một `PATCH` endpoint mới `/doctor/appointments/{id}/status` trong `DoctorAppointmentController`.
- Thêm phương thức `updateStatusByDoctor` vào `AppointmentService` để xử lý logic nghiệp vụ.
- Phương thức service sẽ kiểm tra quyền của bác sĩ và tính hợp lệ của việc chuyển đổi trạng thái trước khi cập nhật database.
- Tạo một DTO mới, `UpdateAppointmentStatusRequest`, để nhận trạng thái mới từ request body.

## Evidence (Screenshot or Video)
**Hình ảnh gọi API thành công**: Gọi API `PATCH /api/v1/doctor/appointments/{id}/status` với trạng thái mới là `COMPLETED`. API trả về Status `200 OK` và dữ liệu cho thấy lịch hẹn đã được cập nhật thành công.
<img width="1340" height="803" alt="image" src="https://github.com/user-attachments/assets/00a087cc-4cbd-4263-81d2-3e4b5e47fefa" />