### PR TITLE
fix: refactor migration database syntax

### DIFF
--- a/backend/src/main/resources/db/migration/V7__update_constraints_for_notifications_and_appointments.sql
+++ b/backend/src/main/resources/db/migration/V7__update_constraints_for_notifications_and_appointments.sql
@@ -1,13 +1,13 @@
 -- Update CHECK constraints for MySQL 8+
 
 -- Drop existing appointment status check and add REJECTED
-ALTER TABLE appointments DROP CONSTRAINT IF EXISTS chk_appointment_status;
+ALTER TABLE appointments DROP CHECK chk_appointment_status;
 ALTER TABLE appointments
   ADD CONSTRAINT chk_appointment_status
   CHECK (status IN ('PENDING','CONFIRMED','CANCELLED','COMPLETED','REJECTED'));
 
 -- Drop existing notification type check and extend values
-ALTER TABLE notifications DROP CONSTRAINT IF EXISTS chk_notification_type;
+ALTER TABLE notifications DROP CHECK chk_notification_type;
 ALTER TABLE notifications
   ADD CONSTRAINT chk_notification_type
   CHECK (type IN (
@@ -24,3 +24,4 @@ ALTER TABLE notifications
     'PAYMENT_SUCCESS',
     'GENERAL_ANNOUNCEMENT'
   )); 
+  


### PR DESCRIPTION
## Related Tickets
- [#TicketID](https://edu-redmine.sun-asterisk.vn/issues/92382)

## WHAT (optional)
- Sữa lỗi syntax của migration database về lại chuẩn MySQL

## WHY
- Vì em dùng MySQL của Xampp là mariadb nên có chút khác biệt, em có sửa lại để dùng, tuy nhiên khi push lên thì thành viên nhóm không chạy được